### PR TITLE
proposal: reference tooling and CLI surface

### DIFF
--- a/proposals/0002-reference-tooling-and-cli-surface.md
+++ b/proposals/0002-reference-tooling-and-cli-surface.md
@@ -1,0 +1,51 @@
+# Proposal 0002: Reference Tooling + CLI Surface
+
+## Status
+Draft
+
+## Motivation
+Fact-RAR is easy to prototype in prompts, but adoption increases when users can validate and normalize artifacts locally with repeatable tooling.
+
+## Goal
+Define a minimal reference tooling surface that keeps the language lightweight while making workflows deterministic.
+
+## Non-goals
+- Not replacing LLM-based encoding.
+- Not forcing a single runtime or package ecosystem.
+- Not requiring canonical mode for casual use.
+
+## Proposed CLI Commands
+
+```bash
+factrar encode   # assistive encode pipeline (optional LLM adapter hooks)
+factrar decode   # expand to plain-language propositions
+factrar lint     # syntax + style checks
+factrar normalize# canonicalization profile output
+factrar diff     # semantic diff between two Fact-RAR files
+factrar stats    # token/proposition density metrics
+```
+
+## Minimal I/O Contract
+- Input: UTF-8 `.frar` or plain text
+- Output: Fact-RAR text, JSON AST, or markdown report (`--format text|json|md`)
+- Exit codes:
+  - `0` success
+  - `1` lint/validation failures
+  - `2` parser/runtime error
+
+## Initial Lint Rules (Draft)
+1. One clause per line unless in a `with` block.
+2. Flag pronouns in canonical mode.
+3. Warn on ambiguous nested sets/lists.
+4. Warn when both `!` and `¬` appear in same document.
+5. Warn on missing explicit subjects in multi-line blocks.
+
+## Adoption Plan
+- Phase 1: parser + lint + normalize
+- Phase 2: diff + stats
+- Phase 3: optional encode/decode adapters and benchmark harness hooks
+
+## Open Questions
+- Should semantic diff rely on normalized AST only?
+- Should `encode` be plugin-based to support multiple model providers?
+- Should benchmark output format be JSONL by default?

--- a/proposals/0002-reference-tooling-and-cli-surface.md
+++ b/proposals/0002-reference-tooling-and-cli-surface.md
@@ -4,10 +4,10 @@
 Draft
 
 ## Motivation
-Fact-RAR is easy to prototype in prompts, but adoption increases when users can validate and normalize artifacts locally with repeatable tooling.
+Fact-RAR is easy to prototype in prompts, but adoption increases when humans can validate, compare, and trust artifacts locally with repeatable tooling.
 
 ## Goal
-Define a minimal reference tooling surface that keeps the language lightweight while making workflows deterministic.
+Define a minimal reference tooling surface that keeps the language lightweight while making workflows deterministic and understandable to human contributors.
 
 ## Non-goals
 - Not replacing LLM-based encoding.
@@ -17,12 +17,12 @@ Define a minimal reference tooling surface that keeps the language lightweight w
 ## Proposed CLI Commands
 
 ```bash
-factrar encode   # assistive encode pipeline (optional LLM adapter hooks)
-factrar decode   # expand to plain-language propositions
-factrar lint     # syntax + style checks
-factrar normalize# canonicalization profile output
-factrar diff     # semantic diff between two Fact-RAR files
-factrar stats    # token/proposition density metrics
+factrar encode    # assistive encode pipeline (optional LLM adapter hooks)
+factrar decode    # expand to plain-language propositions for human review
+factrar lint      # syntax + style checks with readable diagnostics
+factrar normalize # canonicalization profile output for consistency
+factrar diff      # semantic diff between two Fact-RAR files (change summary)
+factrar stats     # human-readable density/clarity metrics report
 ```
 
 ## Minimal I/O Contract
@@ -32,6 +32,11 @@ factrar stats    # token/proposition density metrics
   - `0` success
   - `1` lint/validation failures
   - `2` parser/runtime error
+
+## Human-First Output Defaults (Proposed)
+- Default output should be concise text/markdown that a non-implementer can read quickly.
+- Machine formats (JSON/AST) should be opt-in via `--format json`.
+- `factrar stats` should explain *why* a score changed (for example: more clauses, fewer ambiguities, improved consistency), not only print raw numbers.
 
 ## Initial Lint Rules (Draft)
 1. One clause per line unless in a `with` block.
@@ -48,4 +53,4 @@ factrar stats    # token/proposition density metrics
 ## Open Questions
 - Should semantic diff rely on normalized AST only?
 - Should `encode` be plugin-based to support multiple model providers?
-- Should benchmark output format be JSONL by default?
+- Should the default reporting profile prioritize human-readable markdown over JSONL?

--- a/tooling/factrar-cli/README.md
+++ b/tooling/factrar-cli/README.md
@@ -1,0 +1,22 @@
+# factrar-cli (proposed)
+
+This directory is a placeholder for a future reference CLI implementation.
+
+## Proposed UX
+
+```bash
+# Validate a file
+factrar lint knowledge.frar
+
+# Normalize to canonical form
+factrar normalize knowledge.frar > knowledge.norm.frar
+
+# Compare semantic changes across revisions
+factrar diff old.frar new.frar --format md
+
+# Show density stats
+factrar stats knowledge.frar
+```
+
+## Design Principle
+Tooling should make Fact-RAR **easier to trust and automate**, without changing its primary role as a semantic-packing language for cross-model transfer.

--- a/tooling/factrar-cli/README.md
+++ b/tooling/factrar-cli/README.md
@@ -14,9 +14,9 @@ factrar normalize knowledge.frar > knowledge.norm.frar
 # Compare semantic changes across revisions
 factrar diff old.frar new.frar --format md
 
-# Show density stats
+# Show density stats with readable explanations
 factrar stats knowledge.frar
 ```
 
 ## Design Principle
-Tooling should make Fact-RAR **easier to trust and automate**, without changing its primary role as a semantic-packing language for cross-model transfer.
+Tooling should make Fact-RAR **easier for humans to trust, review, and automate**, without changing its primary role as a semantic-packing language for cross-model transfer.


### PR DESCRIPTION
## Summary
Adds a draft proposal for reference tooling and a minimal CLI surface for Fact-RAR workflows.

## Adds
- `proposals/0002-reference-tooling-and-cli-surface.md`
- `tooling/factrar-cli/README.md` placeholder for future implementation
- Proposed commands (`lint`, `normalize`, `diff`, `stats`, etc.)
- Draft rollout phases and lint rules

## Why
This creates a concrete path from spec-only usage to repeatable, automatable workflows.
